### PR TITLE
Fix yaml RepresenterError during posting audit

### DIFF
--- a/openprocurement/auction/insider/auction.py
+++ b/openprocurement/auction/insider/auction.py
@@ -336,8 +336,7 @@ class Auction(DutchDBServiceMixin,
             method that generate audit from auction document from db
         """
         self.generate_request_id()
-        auction_data = self.get_auction_document()
-        self._auction_data = {"data": auction_data}
+        self.get_auction_info()
         self.audit = prepare_audit(self)
         self.audit['timeline']['auction_start']['time'] = self.auction_document["stages"][0]['start']
         self.audit['timeline'][DUTCH]['timeline']['start'] = self.auction_document["stages"][1]['start']


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/devel/openprocurement.auction.buildout/bin/auction_insider", line 116, in <module>
    sys.exit(openprocurement.auction.insider.cli.main())
  File "/home/devel/.buildout/eggs/openprocurement.auction.insider-1.0.2a14-py2.7.egg/openprocurement/auction/insider/cli.py", line 82, in main
    auction.prepare_auction_document()
  File "/home/devel/.buildout/eggs/openprocurement.auction.insider-1.0.2a14-py2.7.egg/openprocurement/auction/insider/mixins.py", line 129, in prepare_auction_document
    self.post_audit()
  File "/home/devel/.buildout/eggs/openprocurement.auction.insider-1.0.2a14-py2.7.egg/openprocurement/auction/insider/auction.py", line 388, in post_audit
    'Audit data: \n {}'.format(yaml_dump(self.audit)),
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/__init__.py", line 218, in safe_dump
    return dump_all([data], stream, Dumper=SafeDumper, **kwds)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/__init__.py", line 190, in dump_all
    dumper.represent(data)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 28, in represent
    node = self.represent_data(data)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 57, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 223, in represent_dict
    return self.represent_mapping(u'tag:yaml.org,2002:map', data)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 123, in represent_mapping
    node_value = self.represent_data(item_value)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 57, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 215, in represent_list
    return self.represent_sequence(u'tag:yaml.org,2002:seq', data)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 101, in represent_sequence
    node_item = self.represent_data(item)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 57, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 223, in represent_dict
    return self.represent_mapping(u'tag:yaml.org,2002:map', data)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 123, in represent_mapping
    node_value = self.represent_data(item_value)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 67, in represent_data
    node = self.yaml_representers[None](self, data)
  File "/home/devel/.buildout/eggs/PyYAML-3.11-py2.7-linux-x86_64.egg/yaml/representer.py", line 247, in represent_undefined
    raise RepresenterError("cannot represent an object: %s" % data)
yaml.representer.RepresenterError: cannot represent an object: 3.4034
```